### PR TITLE
Enhance search results with richer details

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -306,6 +306,11 @@ a:hover {
   background: white;
 }
 
+.film-card-selected {
+  border-color: var(--primary);
+  box-shadow: 0 2px 6px rgba(37, 99, 235, 0.15);
+}
+
 .film-poster {
   width: 60px;
   height: 90px;
@@ -330,6 +335,30 @@ a:hover {
   margin-right: var(--space-3);
 }
 
+.film-card-content {
+  overflow: hidden;
+}
+
+.film-meta {
+  margin-top: var(--space-2);
+  color: var(--gray-700);
+  font-size: 0.9rem;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.meta-label {
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-right: var(--space-2);
+}
+
+.film-overview {
+  margin-top: var(--space-3);
+  color: var(--gray-600);
+  font-size: 0.95rem;
+}
+
 /* Search results */
 .search-results {
   margin-top: var(--space-3);
@@ -344,10 +373,45 @@ a:hover {
   padding: var(--space-3);
   border-bottom: 1px solid var(--gray-200);
   cursor: pointer;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-3);
+  align-items: start;
 }
 
 .search-result-item:hover {
   background: var(--gray-50);
+}
+
+.search-result-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.search-result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.rating-badge {
+  background: var(--gray-900);
+  color: white;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.search-overview {
+  margin: 0;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 /* Results page */

--- a/routes/films.js
+++ b/routes/films.js
@@ -250,13 +250,58 @@ router.get('/nominate/:date', requireAuth, validateDate, async (req, res) => {
                   }
 
                   if (data.results && data.results.length > 0) {
+                    const topResults = data.results.slice(0, 5);
+
+                    const enrichedResults = await Promise.all(topResults.map(async function(film) {
+                      try {
+                        const detailResponse = await fetch('/api/film/' + film.id);
+                        const detailData = await detailResponse.json();
+
+                        if (!detailResponse.ok) {
+                          throw new Error(detailData.error || 'Detail fetch failed');
+                        }
+
+                        return { search: film, details: detailData };
+                      } catch (err) {
+                        console.warn('Detail lookup failed for film', film.id, err);
+                        return { search: film, details: null };
+                      }
+                    }));
+
                     results.innerHTML = '<div class="search-results">' +
-                      data.results.slice(0, 5).map(function(film) {
-                        return '<div class="search-result-item" onclick="selectFilm(' + film.id + ')">' +
-                          '<strong>' + film.title + '</strong> ' +
-                          (film.release_date ? '(' + film.release_date.substring(0, 4) + ')' : '') +
-                          '<br><small>' + (film.overview ? film.overview.substring(0, 100) + '...' : '') + '</small>' +
-                          '</div>';
+                      enrichedResults.map(function(result) {
+                        const film = result.details || result.search;
+                        const releaseYear = (film.release_date && film.release_date.substring(0, 4)) || '';
+                        const releaseDate = film.release_date ? new Date(film.release_date).toLocaleDateString() : '';
+                        const runtime = film.runtime ? film.runtime + ' mins' : '';
+                        const genres = Array.isArray(film.genres)
+                          ? film.genres.map(function(g) { return g.name; }).filter(Boolean).join(', ')
+                          : '';
+                        const rating = film.vote_average ? film.vote_average.toFixed(1) : '';
+                        const overview = film.overview ? film.overview.substring(0, 220) + (film.overview.length > 220 ? '...' : '') : '';
+                        const posterPath = film.poster_path || (result.search && result.search.poster_path);
+
+                        return '<div class="search-result-item" onclick="selectFilm(' + result.search.id + ')">' +
+                          (posterPath
+                            ? '<img src="https://image.tmdb.org/t/p/w92' + posterPath + '" class="film-poster">'
+                            : '<div class="poster-placeholder">No poster</div>') +
+                          '<div class="search-result-body">' +
+                            '<div class="search-result-header">' +
+                              '<div>' +
+                                '<strong>' + film.title + '</strong> ' +
+                                (releaseYear ? '(' + releaseYear + ')' : '') +
+                              '</div>' +
+                              (rating ? '<span class="rating-badge">' + rating + '/10</span>' : '') +
+                            '</div>' +
+                            '<div class="film-meta">' +
+                              (releaseDate ? '<div><span class="meta-label">Release:</span> ' + releaseDate + '</div>' : '') +
+                              (runtime ? '<div><span class="meta-label">Runtime:</span> ' + runtime + '</div>' : '') +
+                              (genres ? '<div><span class="meta-label">Genres:</span> ' + genres + '</div>' : '') +
+                            '</div>' +
+                            (overview ? '<p class="film-overview search-overview">' + overview + '</p>' : '') +
+                          '</div>' +
+                          '<div style="clear: both;"></div>' +
+                        '</div>';
                       }).join('') + '</div>';
                   } else {
                     results.innerHTML = '<p>No results found</p>';
@@ -281,35 +326,52 @@ router.get('/nominate/:date', requireAuth, validateDate, async (req, res) => {
                   document.getElementById('searchResults').innerHTML = '';
                   
                   const director = film.credits && film.credits.crew ? film.credits.crew.find(function(c) { return c.job === 'Director'; }) : null;
-                  
-                  let detailsHTML = '<div class="film-card">';
-                  
+                  const genres = Array.isArray(film.genres) ? film.genres.map(function(g) { return g.name; }).filter(Boolean).join(', ') : '';
+                  const releaseDate = film.release_date ? new Date(film.release_date).toLocaleDateString() : '';
+
+                  let detailsHTML = '<div class="film-card film-card-selected">';
+
                   if (film.poster_path) {
                     detailsHTML += '<img src="https://image.tmdb.org/t/p/w92' + film.poster_path + '" class="film-poster">';
                   } else {
                     detailsHTML += '<div class="poster-placeholder">No poster</div>';
                   }
-                  
-                  detailsHTML += '<div><strong>' + film.title + '</strong> ';
-                  
+
+                  detailsHTML += '<div class="film-card-content">';
+                  detailsHTML += '<strong>' + film.title + '</strong> ';
+
                   if (film.release_date) {
                     detailsHTML += '(' + film.release_date.substring(0, 4) + ')';
                   }
-                  
-                  detailsHTML += '<br>';
-                  
+
+                  detailsHTML += '<div class="film-meta">';
+
+                  if (releaseDate) {
+                    detailsHTML += '<div><span class="meta-label">Release:</span> ' + releaseDate + '</div>';
+                  }
+
                   if (director) {
-                    detailsHTML += 'Director: ' + director.name + '<br>';
+                    detailsHTML += '<div><span class="meta-label">Director:</span> ' + director.name + '</div>';
                   }
-                  
+
                   if (film.runtime) {
-                    detailsHTML += 'Runtime: ' + film.runtime + ' mins<br>';
+                    detailsHTML += '<div><span class="meta-label">Runtime:</span> ' + film.runtime + ' mins</div>';
                   }
-                  
+
+                  if (genres) {
+                    detailsHTML += '<div><span class="meta-label">Genres:</span> ' + genres + '</div>';
+                  }
+
                   if (film.vote_average) {
-                    detailsHTML += 'Rating: ' + film.vote_average + '/10';
+                    detailsHTML += '<div><span class="meta-label">Rating:</span> ' + film.vote_average + '/10</div>';
                   }
-                  
+
+                  detailsHTML += '</div>';
+
+                  if (film.overview) {
+                    detailsHTML += '<p class="film-overview">' + film.overview + '</p>';
+                  }
+
                   detailsHTML += '</div><div style="clear: both;"></div></div>';
                   
                   document.getElementById('selectedDetails').innerHTML = detailsHTML;


### PR DESCRIPTION
## Summary
- enrich search results by fetching film details and showing posters, rating, release date, runtime, genres, and fuller overviews
- style search result items with a structured layout, rating badge, and clamped overview text for readability
- handle failed detail lookups gracefully while keeping search responsive

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283208de9c8326b610ad82c558f567)