### PR TITLE
Show nominations on calendar view

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -254,12 +254,19 @@ a:hover {
   margin-bottom: var(--space-4);
   border: 1px solid var(--gray-200);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 
 .week-card:hover {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.week-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-4);
 }
 
 .week-info h3 {
@@ -357,6 +364,96 @@ a:hover {
   margin-top: var(--space-3);
   color: var(--gray-600);
   font-size: 0.95rem;
+}
+
+/* Nominations preview */
+.nomination-list {
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, #f8fafc, #eef2ff);
+  border: 1px solid var(--gray-200);
+}
+
+.nominations-preview {
+  padding: var(--space-3);
+  border-radius: var(--radius);
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+}
+
+.nomination-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
+.nomination-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: white;
+  font-weight: 700;
+}
+
+.nomination-subtitle {
+  margin: 0;
+  color: var(--gray-700);
+  font-weight: 600;
+}
+
+.nomination-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-3);
+}
+
+.nomination-card {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3);
+  border-radius: var(--radius);
+  background: white;
+  border: 1px solid var(--gray-200);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.nomination-poster {
+  width: 50px;
+  height: 75px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.poster-placeholder-small {
+  width: 50px;
+  height: 75px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: var(--gray-200);
+  color: var(--gray-500);
+  font-size: 0.7rem;
+  text-align: center;
+}
+
+.nomination-title {
+  font-weight: 700;
+  color: var(--gray-900);
+}
+
+.nomination-meta {
+  color: var(--gray-600);
+  margin-top: 2px;
+  font-size: 0.9rem;
 }
 
 /* Search results */
@@ -485,7 +582,12 @@ a:hover {
     flex-direction: column;
     align-items: stretch;
   }
-  
+
+  .week-main {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   .actions .btn {
     text-align: center;
   }

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -39,57 +39,93 @@ router.get('/', requireAuth, (req, res) => {
       weeks = [];
     }
 
-    // Helper functions
-    function getMondayOfWeek(date) {
-      const d = new Date(date);
-      const day = d.getDay();
-      const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-      return new Date(d.setDate(diff));
-    }
+    const weekIds = weeks.filter(w => w.id).map(w => w.id);
 
-    function formatDate(date) {
-      return date.toISOString().split('T')[0];
-    }
+    const getNominations = (callback) => {
+      if (!weekIds.length) {
+        return callback({});
+      }
 
-    function formatDisplayDate(date) {
-      return date.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined
+      const placeholders = weekIds.map(() => '?').join(',');
+
+      req.db.all(`
+        SELECT n.week_id, f.title, f.year, f.poster_url, m.name as nominator
+        FROM nominations n
+        JOIN films f ON n.film_id = f.id
+        JOIN members m ON n.member_id = m.id
+        WHERE n.week_id IN (${placeholders})
+        ORDER BY n.nominated_at
+      `, weekIds, (nomErr, nominations) => {
+        if (nomErr) {
+          console.error('Nominations error:', nomErr);
+          return callback({});
+        }
+
+        const grouped = nominations.reduce((acc, nomination) => {
+          if (!acc[nomination.week_id]) {
+            acc[nomination.week_id] = [];
+          }
+          acc[nomination.week_id].push(nomination);
+          return acc;
+        }, {});
+
+        callback(grouped);
       });
-    }
+    };
 
-    // Generate week slots
-    const currentMonday = getMondayOfWeek(new Date());
-    const weekSlots = [];
+    getNominations((nominationsByWeek) => {
+      // Helper functions
+      function getMondayOfWeek(date) {
+        const d = new Date(date);
+        const day = d.getDay();
+        const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+        return new Date(d.setDate(diff));
+      }
 
-    // Generate from WEEKS_PAST to WEEKS_FUTURE (from constants)
-    for (let i = -WEEKS_PAST; i < WEEKS_FUTURE; i++) {
-      const weekDate = new Date(currentMonday);
-      weekDate.setDate(currentMonday.getDate() + (i * 7));
-      const weekDateStr = formatDate(weekDate);
+      function formatDate(date) {
+        return date.toISOString().split('T')[0];
+      }
 
-      // Find existing week data
-      const existingWeek = weeks.find(w => w.week_date === weekDateStr);
+      function formatDisplayDate(date) {
+        return date.toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined
+        });
+      }
 
-      weekSlots.push({
-        date: weekDateStr,
-        displayDate: formatDisplayDate(weekDate),
-        isCurrent: i === 0,
-        isPast: i < 0,
-        isFuture: i > 0,
-        userHasNomination: existingWeek ? existingWeek.user_nomination_count > 0 : false,
-        ...existingWeek
-      });
-    }
+      // Generate week slots
+      const currentMonday = getMondayOfWeek(new Date());
+      const weekSlots = [];
 
-    // Separate into groups
-    const currentWeek = weekSlots.find(w => w.isCurrent);
-    const upcomingWeeks = weekSlots.filter(w => w.isFuture);
-    const pastWeeks = weekSlots.filter(w => w.isPast);
+      // Generate from WEEKS_PAST to WEEKS_FUTURE (from constants)
+      for (let i = -WEEKS_PAST; i < WEEKS_FUTURE; i++) {
+        const weekDate = new Date(currentMonday);
+        weekDate.setDate(currentMonday.getDate() + (i * 7));
+        const weekDateStr = formatDate(weekDate);
 
-    // Generate HTML
-    res.send(`
+        // Find existing week data
+        const existingWeek = weeks.find(w => w.week_date === weekDateStr);
+
+        weekSlots.push({
+          date: weekDateStr,
+          displayDate: formatDisplayDate(weekDate),
+          isCurrent: i === 0,
+          isPast: i < 0,
+          isFuture: i > 0,
+          userHasNomination: existingWeek ? existingWeek.user_nomination_count > 0 : false,
+          nominations: existingWeek && existingWeek.id ? (nominationsByWeek[existingWeek.id] || []) : [],
+          ...existingWeek
+        });
+      }
+
+      // Separate into groups
+      const currentWeek = weekSlots.find(w => w.isCurrent);
+      const upcomingWeeks = weekSlots.filter(w => w.isFuture);
+      const pastWeeks = weekSlots.filter(w => w.isPast);
+
+      // Generate HTML
+      res.send(`
       <!DOCTYPE html>
       <html>
       <head>
@@ -166,6 +202,29 @@ router.get('/', requireAuth, (req, res) => {
                   <a href="/results/${currentWeek.date}" class="btn btn-secondary">View Results</a>
                 ` : ''}
               </div>
+              ${currentWeek.nominations && currentWeek.nominations.length ? `
+                <div class="nomination-list">
+                  <div class="nomination-list__header">
+                    <h3>🎟️ Current Nominations</h3>
+                    <span class="nomination-count">${currentWeek.nominations.length}</span>
+                  </div>
+                  <div class="nomination-grid">
+                    ${currentWeek.nominations.map(nom => `
+                      <div class="nomination-card">
+                        ${nom.poster_url ? `
+                          <img src="https://image.tmdb.org/t/p/w92${nom.poster_url}" alt="${nom.title} poster" class="nomination-poster">
+                        ` : `
+                          <div class="poster-placeholder poster-placeholder-small">No poster</div>
+                        `}
+                        <div>
+                          <div class="nomination-title">${nom.title}${nom.year ? ` (${nom.year})` : ''}</div>
+                          <div class="nomination-meta">Nominated by ${nom.nominator}</div>
+                        </div>
+                      </div>
+                    `).join('')}
+                  </div>
+                </div>
+              ` : ''}
             </div>
           ` : ''}
 
@@ -174,39 +233,63 @@ router.get('/', requireAuth, (req, res) => {
             <h2>📅 Upcoming Weeks</h2>
             ${upcomingWeeks.map(week => `
               <div class="week-card">
-                <div class="week-info">
-                  <h3>${week.displayDate}</h3>
-                  ${week.genre_name ? `
-                    <p>Genre: <strong>${week.genre_name}</strong></p>
-                  ` : '<p style="color: #999;">No genre set</p>'}
-                  ${week.phase && week.phase !== 'planning' ? `
-                    <span class="phase-badge phase-${week.phase}">${week.phase}</span>
-                  ` : ''}
+                <div class="week-main">
+                  <div class="week-info">
+                    <h3>${week.displayDate}</h3>
+                    ${week.genre_name ? `
+                      <p>Genre: <strong>${week.genre_name}</strong></p>
+                    ` : '<p style="color: #999;">No genre set</p>'}
+                    ${week.phase && week.phase !== 'planning' ? `
+                      <span class="phase-badge phase-${week.phase}">${week.phase}</span>
+                    ` : ''}
+                  </div>
+                  <div class="actions">
+                    ${!week.id || week.phase === 'planning' ? `
+                      <a href="/set-genre/${week.date}" class="btn btn-primary btn-small">${week.genre_name ? 'Update Genre' : 'Set Genre'}</a>
+                      ${week.genre_name && currentUser.isAdmin ? `
+                        <form action="/open-nominations/${week.date}" method="POST" style="display: inline;">
+                          <button type="submit" class="btn btn-success btn-small">Open Nominations</button>
+                        </form>
+                      ` : ''}
+                    ` : week.phase === 'nomination' ? `
+                      <a href="/nominate/${week.date}" class="btn btn-success btn-small">
+                        ${week.userHasNomination ? 'Change Nomination' : 'Nominate'}
+                      </a>
+                      ${week.nomination_count >= 3 && currentUser.isAdmin ? `
+                        <a href="/begin-voting/${week.date}" class="btn btn-warning btn-small">Begin Voting</a>
+                      ` : ''}
+                    ` : week.phase === 'voting' ? `
+                      <a href="/vote/${week.date}" class="btn btn-warning btn-small">Vote</a>
+                      ${currentUser.isAdmin ? `
+                        <a href="/calculate-results/${week.date}" class="btn btn-primary btn-small">Calculate Results</a>
+                      ` : ''}
+                    ` : week.phase === 'complete' ? `
+                      <a href="/results/${week.date}" class="btn btn-secondary btn-small">Results</a>
+                    ` : ''}
+                  </div>
                 </div>
-                <div class="actions">
-                  ${!week.id || week.phase === 'planning' ? `
-                    <a href="/set-genre/${week.date}" class="btn btn-primary btn-small">${week.genre_name ? 'Update Genre' : 'Set Genre'}</a>
-                    ${week.genre_name && currentUser.isAdmin ? `
-                      <form action="/open-nominations/${week.date}" method="POST" style="display: inline;">
-                        <button type="submit" class="btn btn-success btn-small">Open Nominations</button>
-                      </form>
-                    ` : ''}
-                  ` : week.phase === 'nomination' ? `
-                    <a href="/nominate/${week.date}" class="btn btn-success btn-small">
-                      ${week.userHasNomination ? 'Change Nomination' : 'Nominate'}
-                    </a>
-                    ${week.nomination_count >= 3 && currentUser.isAdmin ? `
-                      <a href="/begin-voting/${week.date}" class="btn btn-warning btn-small">Begin Voting</a>
-                    ` : ''}
-                  ` : week.phase === 'voting' ? `
-                    <a href="/vote/${week.date}" class="btn btn-warning btn-small">Vote</a>
-                    ${currentUser.isAdmin ? `
-                      <a href="/calculate-results/${week.date}" class="btn btn-primary btn-small">Calculate Results</a>
-                    ` : ''}
-                  ` : week.phase === 'complete' ? `
-                    <a href="/results/${week.date}" class="btn btn-secondary btn-small">Results</a>
-                  ` : ''}
-                </div>
+                ${week.nominations && week.nominations.length ? `
+                  <div class="nominations-preview">
+                    <div class="nomination-list__header">
+                      <p class="nomination-subtitle">${week.nominations.length} nomination${week.nominations.length === 1 ? '' : 's'}</p>
+                    </div>
+                    <div class="nomination-grid">
+                      ${week.nominations.map(nom => `
+                        <div class="nomination-card">
+                          ${nom.poster_url ? `
+                            <img src="https://image.tmdb.org/t/p/w92${nom.poster_url}" alt="${nom.title} poster" class="nomination-poster">
+                          ` : `
+                            <div class="poster-placeholder poster-placeholder-small">No poster</div>
+                          `}
+                          <div>
+                            <div class="nomination-title">${nom.title}${nom.year ? ` (${nom.year})` : ''}</div>
+                            <div class="nomination-meta">${nom.nominator}</div>
+                          </div>
+                        </div>
+                      `).join('')}
+                    </div>
+                  </div>
+                ` : ''}
               </div>
             `).join('')}
           </div>


### PR DESCRIPTION
## Summary
- fetch and group week nominations so the calendar can surface nominated films
- display nomination cards for current and upcoming weeks with poster thumbnails and nominators
- add styling for the new nomination previews and adjust layout of week cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692838d741d48326a6e39a887eab2cb3)