### PR TITLE
Handle zero-point vote totals

### DIFF
--- a/database/setup.js
+++ b/database/setup.js
@@ -254,9 +254,9 @@ const dbHelpers = {
   // Calculate results
   calculateResults: function(weekId, callback) {
     db.get(`
-      SELECT 
+      SELECT
         n.id as nomination_id,
-        SUM(v.points) as total_points
+        COALESCE(SUM(v.points), 0) as total_points
       FROM nominations n
       LEFT JOIN votes v ON n.id = v.nomination_id
       WHERE n.week_id = ?


### PR DESCRIPTION
## Summary
- ensure calculating results treats nominations with no votes as zero points
- prevent calculate-results endpoint from failing when total_points was null

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283dddab1c8326b60a0b5ecf25c2fa)