### PR TITLE
Handle calculate results without nominations

### DIFF
--- a/database/setup.js
+++ b/database/setup.js
@@ -271,10 +271,14 @@ const dbHelpers = {
 
       const winner = nominations[0];
 
-      // Store result
+      // Store result (idempotent for repeated calculations)
       db.run(
-        `INSERT OR REPLACE INTO results (week_id, winning_nomination_id, total_points)
-         VALUES (?, ?, ?)`,
+        `INSERT INTO results (week_id, winning_nomination_id, total_points)
+         VALUES (?, ?, ?)
+         ON CONFLICT(week_id) DO UPDATE SET
+           winning_nomination_id = excluded.winning_nomination_id,
+           total_points = excluded.total_points,
+           calculated_at = CURRENT_TIMESTAMP`,
         [weekId, winner.nomination_id, winner.total_points],
         (err) => {
           if (!err) {

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -326,7 +326,10 @@ const calculateResultsHandler = (req, res) => {
     dbHelpers.calculateResults(week.id, (err, winner) => {
       if (err) {
         console.error('Calculate results error:', err);
-        return res.status(500).send('Failed to calculate results');
+        const message = err.message === 'No nominations found for this week'
+          ? 'Cannot calculate results because this week has no nominations.'
+          : 'Failed to calculate results';
+        return res.status(400).send(message);
       }
       res.redirect(`/results/${weekDate}`);
     });


### PR DESCRIPTION
## Summary
- guard result calculation against weeks without nominations and keep zero-vote totals supported
- return a clearer response when an admin tries to calculate results with no nominations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283dddab1c8326b60a0b5ecf25c2fa)