### PR TITLE
Allow genre changes during nomination phase

### DIFF
--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -190,6 +190,7 @@ router.get('/', requireAuth, (req, res) => {
                   <a href="/nominate/${currentWeek.date}" class="btn btn-success">
                     ${currentWeek.userHasNomination ? 'Change Nomination' : 'Nominate Film'}
                   </a>
+                  <a href="/set-genre/${currentWeek.date}" class="btn btn-primary">Change Genre</a>
                   ${currentWeek.nomination_count >= 3 && currentUser.isAdmin ? `
                     <a href="/begin-voting/${currentWeek.date}" class="btn btn-warning">Begin Voting</a>
                   ` : ''}
@@ -255,6 +256,7 @@ router.get('/', requireAuth, (req, res) => {
                       <a href="/nominate/${week.date}" class="btn btn-success btn-small">
                         ${week.userHasNomination ? 'Change Nomination' : 'Nominate'}
                       </a>
+                      <a href="/set-genre/${week.date}" class="btn btn-primary btn-small">Change Genre</a>
                       ${week.nomination_count >= 3 && currentUser.isAdmin ? `
                         <a href="/begin-voting/${week.date}" class="btn btn-warning btn-small">Begin Voting</a>
                       ` : ''}

--- a/routes/weeks.js
+++ b/routes/weeks.js
@@ -103,11 +103,15 @@ router.post('/set-genre/:date', requireAuth, validateDate, (req, res) => {
 
   // Function to create or update week
   function setWeekGenre(finalGenreId) {
-    // Check if week exists
-    req.db.get("SELECT id FROM weeks WHERE week_date = ?", [weekDate], (err, week) => {
+    // Check if week exists and ensure phase allows updates
+    req.db.get("SELECT id, phase FROM weeks WHERE week_date = ?", [weekDate], (err, week) => {
       if (err) {
         console.error(err);
         return res.status(500).send('Database error');
+      }
+
+      if (week && week.phase && !['planning', 'nomination'].includes(week.phase)) {
+        return res.status(400).send('Cannot change genre after voting has started.');
       }
 
       if (week) {


### PR DESCRIPTION
## Summary
- show Change Genre actions for weeks in the nomination phase so genres can be updated before voting starts
- block genre updates once voting or later phases have begun to keep past weeks stable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929157c91e0832686c9589dfdb0e263)