### PR TITLE
Fix calendar vote count to reflect unique voters

### DIFF
--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -20,7 +20,7 @@ router.get('/', requireAuth, (req, res) => {
       w.phase,
       g.name as genre_name,
       COUNT(DISTINCT n.id) as nomination_count,
-      COUNT(DISTINCT v.id) as vote_count,
+      COUNT(DISTINCT v.member_id) as vote_count,
       wf.title as winner_title,
       wf.year as winner_year,
       COUNT(DISTINCT CASE WHEN n.member_id = ? THEN n.id END) as user_nomination_count


### PR DESCRIPTION
## Summary
- update calendar week query to count votes by distinct member instead of individual vote records

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692915f2ded48326a53776b99c78b7ce)