### PR TITLE
Add admin reset for current week

### DIFF
--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -202,6 +202,11 @@ router.get('/', requireAuth, (req, res) => {
                 ` : currentWeek.phase === 'complete' ? `
                   <a href="/results/${currentWeek.date}" class="btn btn-secondary">View Results</a>
                 ` : ''}
+                ${currentUser.isAdmin ? `
+                  <form action="/reset-week/${currentWeek.date}" method="POST" style="display: inline;" onsubmit="return confirm('Reset this week? This will remove nominations, votes, and the selected genre.');">
+                    <button type="submit" class="btn btn-danger">Reset Week</button>
+                  </form>
+                ` : ''}
               </div>
               ${currentWeek.nominations && currentWeek.nominations.length ? `
                 <div class="nomination-list">


### PR DESCRIPTION
## Summary
- add an admin-only week reset endpoint that clears nominations, votes, results, and the genre for a given week
- display a Reset Week control on the current week card so admins can restart the week regardless of phase

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692917ed23bc83269a2ec69c17aa09a3)