### PR TITLE
Add touch drag support for vote ranking

### DIFF
--- a/routes/votes.js
+++ b/routes/votes.js
@@ -204,19 +204,44 @@ router.get('/vote/:date', requireAuth, validateDate, (req, res) => {
                       
                       if (list) {
                         const items = list.querySelectorAll('.ranking-item');
-                        
+
                         items.forEach(item => {
                           item.addEventListener('dragstart', function(e) {
                             draggedItem = this;
                             this.classList.add('dragging');
                           });
-                          
+
                           item.addEventListener('dragend', function(e) {
                             this.classList.remove('dragging');
                             draggedItem = null;
                             updateRankNumbers();
                           });
-                          
+
+                          // Touch support for iOS Safari
+                          item.addEventListener('touchstart', function(e) {
+                            draggedItem = this;
+                            this.classList.add('dragging');
+                          }, { passive: true });
+
+                          item.addEventListener('touchmove', function(e) {
+                            if (!draggedItem) return;
+                            const touch = e.touches[0];
+                            const afterElement = getDragAfterElement(list, touch.clientY);
+                            if (afterElement == null) {
+                              list.appendChild(draggedItem);
+                            } else {
+                              list.insertBefore(draggedItem, afterElement);
+                            }
+                            e.preventDefault();
+                          }, { passive: false });
+
+                          item.addEventListener('touchend', function() {
+                            if (!draggedItem) return;
+                            this.classList.remove('dragging');
+                            draggedItem = null;
+                            updateRankNumbers();
+                          });
+
                           item.addEventListener('dragover', function(e) {
                             e.preventDefault();
                             const afterElement = getDragAfterElement(list, e.clientY);


### PR DESCRIPTION
## Summary
- add touch event handling to vote ranking drag and drop
- prevent default touch scrolling during drag and update rank numbers on touch end

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692954ebd6d083268fc0691b46b4e600)