### PR TITLE
Add `/calendar` route alias to fix 404 when changing year

### DIFF
--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -3,7 +3,7 @@ const express = require('express');
 const router = express.Router();
 const { requireAuth } = require('../middleware/auth');
 
-router.get('/', requireAuth, (req, res) => {
+router.get(['/', '/calendar'], requireAuth, (req, res) => {
   const currentUser = req.user; // From session via middleware
 
   // Redirect to login if not authenticated (safety check)


### PR DESCRIPTION
### Motivation
- The calendar year selector submits to `/calendar` but the route previously only listened on `/`, causing `Cannot GET /calendar` errors.
- Accepting `/calendar` as an alias ensures year query requests are routed to the existing calendar handler.

### Description
- Change the route registration from `router.get('/', requireAuth, ...)` to `router.get(['/', '/calendar'], requireAuth, ...)` in `routes/calendar.js` so the handler responds to both paths.
- Leave existing authentication and calendar rendering logic unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c210cc7483269ea67d715ceefd12)